### PR TITLE
Wait for DOMContentLoaded event instead of checking for document.body

### DIFF
--- a/src/Fancybox/Fancybox.js
+++ b/src/Fancybox/Fancybox.js
@@ -1479,6 +1479,8 @@ Fancybox.openers = new Map();
 Fancybox.Plugins = Plugins;
 
 // Auto init with default options
-Fancybox.bind("[data-fancybox]");
+document.addEventListener("DOMContentLoaded", () => {
+  Fancybox.bind("[data-fancybox]");
+});
 
 export { Fancybox };

--- a/src/shared/utils/canUseDOM.js
+++ b/src/shared/utils/canUseDOM.js
@@ -4,6 +4,5 @@
 export const canUseDOM = !!(
   typeof window !== "undefined" &&
   window.document &&
-  window.document.createElement &&
-  window.document.body
+  window.document.createElement
 );


### PR DESCRIPTION
`document.body` might not yet be available during the load of the script (especially with the UMD version). So have to wait for it to become available.

Fixes #81 