### PR TITLE
compensate scrollbar via CSS variable

### DIFF
--- a/src/Fancybox/Fancybox.js
+++ b/src/Fancybox/Fancybox.js
@@ -746,7 +746,7 @@ class Fancybox extends Base {
 
       $style.id = id;
       $style.type = "text/css";
-      $style.innerHTML = `.compensate-for-scrollbar {padding-right: ${scrollbarWidth}px;}`;
+      $style.innerHTML = `.compensate-for-scrollbar {--fancybox-scrollbar-compensate: ${scrollbarWidth}px;}`;
 
       document.getElementsByTagName("head")[0].appendChild($style);
 

--- a/src/Fancybox/scss/base.scss
+++ b/src/Fancybox/scss/base.scss
@@ -5,6 +5,7 @@ html.with-fancybox {
 body.compensate-for-scrollbar {
   overflow: hidden !important;
   touch-action: none;
+  padding-right: var(--fancybox-scrollbar-compensate, 0);
 }
 
 .fancybox__container {


### PR DESCRIPTION
Hi, what do you think about this approach of changing scrollbar compensation from adding a direct padding in generated styles to CSS variable, that can be also used in the entire document.
This can help developers to handle cases with fixed elements, that are shifted when Fancybox gets open.
For example, 
```css
.header {
  position: fixed;
  left: 0;
  top: 0;
  max-width: calc(100% - var(--fancybox-scrollbar-compensate, 0));
}
```
And no JS callbacks with manual adding styles is needed anymore